### PR TITLE
添加maven-compiler-plugin，设置jdk版本为1.6

### DIFF
--- a/rop/pom.xml
+++ b/rop/pom.xml
@@ -209,4 +209,17 @@
             <version>2.0.0-RC2</version>
         </dependency>
     </dependencies>
+    
+    <build>
+    	<plugins>
+    		<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+    	</plugins>
+    </build>
 </project>


### PR DESCRIPTION
添加maven-compiler-plugin，设置jdk版本为1.6,这样@Override在eclipse中不会出现错误，现在jdk1.6已经普及了。
