### PR TITLE
删除多余依赖，去掉对log4j的强依赖，用户可能会使用其他日志组建接slf4j，如logback等。

### DIFF
--- a/rop/pom.xml
+++ b/rop/pom.xml
@@ -56,13 +56,8 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <optional>true</optional>
             <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
         </dependency>
 
         <dependency>
@@ -79,12 +74,6 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>${spring.version}</version>
         </dependency>
@@ -95,17 +84,6 @@
             <version>${hibernate.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-jaxrs</artifactId>
@@ -294,7 +272,6 @@
 
         <jackson.version>1.9.5</jackson.version>
         <slf4j.version>1.6.1</slf4j.version>
-        <log4j.version>1.2.16</log4j.version>
         <hibernate.version>4.2.0.Final</hibernate.version>
         <codec.version>1.6</codec.version>
         <jackson.xml.version>2.3.2-jdk1.5</jackson.xml.version>


### PR DESCRIPTION
1. 去掉对log4j的强依赖，slf4j-log4j12会传递依赖log4j，且设置未可选，不进行传递。用户可能会使用其他日志组建对接slf4j，比如logback等

2.pom去除多余的显示包依赖，spring-context-support由spring-webmvc依赖
   同理去除jackson-core-asl、jackson-mapper-asl直接依赖
